### PR TITLE
Fix certificate issue when launching Puppeteer

### DIFF
--- a/src/Browser/index.ts
+++ b/src/Browser/index.ts
@@ -20,9 +20,10 @@ export const getAuthTokenFromBroswer = async (): Promise<string> => {
         const browser = await puppeteer.launch({
             headless: process.env.HEADLESS?.toLowerCase() == 'false' ? false : 'shell',
             slowMo: 10,
-            args: ['--no-sandbox', '--disable-setuid-sandbox', '--disk-cache-size=0'],
+            args: ['--no-sandbox', '--disable-setuid-sandbox', '--disk-cache-size=0', '--ignore-certificate-errors'],
             executablePath: executablePath(),
             timeout: 0,
+            acceptInsecureCerts: true,
         });
         const [page] = await browser.pages();
 


### PR DESCRIPTION
## Summary
- ignore TLS errors when launching Puppeteer

## Testing
- `npm run eslint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865e18797b883308f08f76e396698c5